### PR TITLE
add changes for normal work and build

### DIFF
--- a/custom-llvm/build-debug.sh
+++ b/custom-llvm/build-debug.sh
@@ -49,7 +49,7 @@ cp -r $futag_src/Checkers/lib/$CheckerCMakeLists $custom_llvm/clang/lib/StaticAn
 
 cmake  -G "Unix Makefiles"  -DLLVM_BUILD_TESTS=OFF  -DLLVM_ENABLE_ZLIB=ON  -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$futag_install_folder  -DCMAKE_EXPORT_COMPILE_COMMANDS=1  -DCLANG_INCLUDE_DOCS="OFF"  -DLLVM_BUILD_LLVM_DYLIB="ON"  -DLLVM_ENABLE_BINDINGS="OFF"  -DLLVM_ENABLE_PROJECTS='clang;'  -DLLVM_ENABLE_WARNINGS="OFF"  -DLLVM_INCLUDE_BENCHMARKS="OFF"  -DLLVM_INCLUDE_DOCS="OFF"  -DLLVM_INCLUDE_EXAMPLES="OFF"  -DLLVM_INCLUDE_TESTS="OFF"  -DLLVM_LINK_LLVM_DYLIB="ON"  -DLLVM_TARGETS_TO_BUILD="host" -DLLVM_ENABLE_RUNTIMES="compiler-rt;"  $custom_llvm/llvm
 
-make -j16 && make -j16 install
+make -j$(($(nproc)/2)) && make -j$(($(nproc)/2)) install
 
 if [ -d $futag_install_folder/python-package ]
 then

--- a/custom-llvm/build.sh
+++ b/custom-llvm/build.sh
@@ -63,7 +63,7 @@ if [ $llvmVersion == "LLVM=13.0.1" ]; then
 
 fi
 
-make -j16 && make -j16 install
+make -j$(($(nproc)/2)) && make -j$(($(nproc)/2)) install
 
 if [ -d $futag_install_folder/python-package ]
 then

--- a/custom-llvm/buildwAFLplusplus.sh
+++ b/custom-llvm/buildwAFLplusplus.sh
@@ -62,7 +62,7 @@ if [ $llvmVersion == "LLVM=13.0.1" ]; then
     cmake  -G "Unix Makefiles"  -DLLVM_BUILD_TESTS=OFF  -DLLVM_ENABLE_ZLIB=OFF  -DCMAKE_BUILD_TYPE=Release  -DLLVM_BINUTILS_INCDIR=/usr/include/  -DCMAKE_INSTALL_PREFIX=$futag_install_folder  -DCMAKE_EXPORT_COMPILE_COMMANDS=1  -DCLANG_INCLUDE_DOCS="OFF"  -DLLVM_BUILD_LLVM_DYLIB="ON"  -DLLVM_ENABLE_BINDINGS="OFF"  -DLLVM_ENABLE_PROJECTS='clang;compiler-rt;'  -DLLVM_ENABLE_WARNINGS="OFF"  -DLLVM_INCLUDE_BENCHMARKS="OFF"  -DLLVM_INCLUDE_DOCS="OFF"  -DLLVM_INCLUDE_EXAMPLES="OFF"  -DLLVM_INCLUDE_TESTS="OFF"  -DLLVM_LINK_LLVM_DYLIB="ON"  -DLLVM_TARGETS_TO_BUILD="host"  $custom_llvm/llvm
 
 fi
-make -j16 && make -j16 install
+make -j$(($(nproc)/2)) && make -j$(($(nproc)/2)) install
 
 export PATH="$(pwd)/bin:$PATH"
 export LLVM_CONFIG="$(pwd)/bin/llvm-config"
@@ -70,8 +70,8 @@ export LD_LIBRARY_PATH="$(llvm-config --libdir)${LD_LIBRARY_PATH:+:$LD_LIBRARY_P
 
 #build AFLplusplus
 cd AFLplusplus-4.02c
-make -j16 distrib
-make -j16 DESTDIR=$futag_install_folder/AFLplusplus install
+make -j$(($(nproc)/2)) distrib
+make -j$(($(nproc)/2)) DESTDIR=$futag_install_folder/AFLplusplus install
 cd ..
 
 if [ -d $futag_install_folder/python-package ]

--- a/product-tests/package-test/ubuntu22/Docker-test-package.Dockerfile
+++ b/product-tests/package-test/ubuntu22/Docker-test-package.Dockerfile
@@ -13,7 +13,7 @@ RUN apt install -y libncurses5 gcc-multilib g++ make gdb binutils python3 git op
 
 USER futag
 WORKDIR /home/futag/
-ADD futag-llvm.latest.tar.xz /home/futag/
+ADD futag-llvm.latest.tar.xz /home/futag/Futag
 
 USER root
 WORKDIR /home/futag/Futag/


### PR DESCRIPTION
С флагом `-j16` сборка может быть нестабильной, требуется много ресурсов на виртуальной машине для того, чтобы его собрать, терминал довольно часто вылетает, а некоторые шаги сборки завершаются с ошибкой. Гораздо логичнее проводить сборку на половине ядер, выделенных машине, так сборка будет проводиться хоть и медленнее, но гораздо стабильнее.
Также, исправлена ошибка в докерфайле `ubuntu22`, путь `/home/futag/Futag` не существовал, хотя он требуется для архива.
С данными изменениями сборка проходит стабильно, докер образ `ubuntu22` работает корректно.